### PR TITLE
Add `-start` to release tag

### DIFF
--- a/src/Final-Release.md
+++ b/src/Final-Release.md
@@ -97,8 +97,8 @@
 1. Tag the release **on the release branch**:
 
    ```shell
-   git tag --annotate --message="Release $NEWVER" $NEWVER
-   git push upstream $NEWVER
+   git tag --annotate --message="Release $NEWVER" $NEWVER-start
+   git push upstream $NEWVER-start
    ```
 
 1. Update [nixos-homepage](https://github.com/NixOS/nixos-homepage) for


### PR DESCRIPTION
Add `-initial` to release tag

Releases are never final. Previously, when the `-initial` suffix
wasn't there, the tags have caused confusion and security
problems when user configurations accidentally reference
the tag instead of the release branch.

Refs https://github.com/NixOS/nixpkgs/pull/124364
Closes #45 