### PR TITLE
Add llvm to release-critical packages

### DIFF
--- a/src/Release-Critical-Packages.md
+++ b/src/Release-Critical-Packages.md
@@ -14,6 +14,7 @@ iterations for these fixes to be applied.
 - `binutils`
 - `gcc`
 - `glibc`
+- `llvm`
 - `systemd`
 
 ### Process for Modifying Release Critical Packages


### PR DESCRIPTION
As part of https://discourse.nixos.org/t/21-05-retrospective/13426/8