### PR TITLE
Release-Process-Walkthrough: Add `oldestSupportedRelease`

### DIFF
--- a/src/Release-Process-Walkthrough.md
+++ b/src/Release-Process-Walkthrough.md
@@ -242,4 +242,4 @@ nix-shell -p "python3.withPackages (p: [ p.lxml p.requests p.pytest ])" -p cdrki
 ## A Month after Release
 
 1. [EOL Channels should be marked unmaintained](https://github.com/NixOS/nixos-org-configurations/pull/201)
-
+2. Increase the `oldestSupportedRelease` in `lib/trivial.nix` to match the oldest non-EOL release.


### PR DESCRIPTION
Add `oldestSupportedRelease` to EOL process.
This variable controls the activation of deprecation messages.

Blocked on https://github.com/NixOS/nixpkgs/pull/163451.
