### PR TITLE
Schedule the retrospective earlier

### DIFF
--- a/src/Release-Process.md
+++ b/src/Release-Process.md
@@ -22,7 +22,7 @@ With [RFC85](https://github.com/NixOS/rfcs/blob/master/rfcs/0085-nixos-release-s
 | -1 Weeks | `release` | Prepare for release, finish remaining issues |
 | 0 Weeks | `release` | **Release!** |
 | 0 Weeks | | ZHF Ends |
-| +4 Weeks | | Release Retrospective and final cleanup |
+| +1 Weeks | | Release Retrospective and final cleanup |
 
 Clarification of terms:
 

--- a/src/Release-Process.md
+++ b/src/Release-Process.md
@@ -22,7 +22,9 @@ With [RFC85](https://github.com/NixOS/rfcs/blob/master/rfcs/0085-nixos-release-s
 | -1 Weeks | `release` | Prepare for release, finish remaining issues |
 | 0 Weeks | `release` | **Release!** |
 | 0 Weeks | | ZHF Ends |
-| +1 Weeks | | Release Retrospective and final cleanup |
+| +1 Weeks | | Release Retrospective |
+| +4 Weeks | | End of life cleanup |
+
 
 Clarification of terms:
 


### PR DESCRIPTION
The time between the release and its retrospective should be shorter, so people remember better how they felt about the release. The four week offset led to noone really participating during the last release.