### PR TITLE
Update once appointed todos

### DIFF
--- a/src/Once-Appointed.md
+++ b/src/Once-Appointed.md
@@ -9,17 +9,17 @@ The release manager of the previous release will get in contact with you and hel
 This is not an actual part of the release process but rather preparations for starting the process.
 
 - Get in contact with the previous release manager and schedule a meeting
-- Enter the [release management Matrix room](https://matrix.to/#/#nixos-release-management:nixos.org)
+- Join the [release management room](https://matrix.to/#/#nixos-release-management:nixos.org) on Matrix
+	- Request moderator permissions on the room, this allows to manage the topic and create video calls
 - Gain access to the [release-manager GitHub Team](https://github.com/orgs/NixOS/teams/nixos-release-managers/members) by asking any of the existing people with "Manager" rights
 	- Also make sure there are only people left as members who are managing this release
 - Ensure you have a [Hydra](https://hydra.nixos.org/) account which will come in handy
 	- Ensure that all release managers have at least `restart-jobs`, `bump-to-front`, and `cancel-build` privileges (see the top-right "Preferences" button). If they are missing, reach out to the Infrastructure team
 - Create a blockers [project](https://github.com/orgs/NixOS/projects) in the organization for your release and the next one
 	- Also close old ones while you're at it and consider migrating remaining open issues to the current project
-- You may also create a [release milestone](https://github.com/NixOS/nixpkgs/milestones) in the nixpkgs project. This is not really used for the process but people from different subsystems often use it. If you don't create it, someone else will probably do so
-	- Close milestones of previous releases
 - Figure out a codename for the next release (not the one you are releasing but the next one) and write it down somewhere for the branch-off
 - Find someone to create a [logo](https://github.com/NixOS/nixos-artwork/tree/master/releases) or create one yourself for the current release and PR it into the repository
+	- Usually done by creating an issue on the `nixos-artwork` repository pinging artists who created previous logos
 - Check if the process can be improved this release
 	- Find comments on the Discourse posts, GitHub issues, … of the previous release and see if the comments suggest doing something different this time
 	- Read the Discourse post of the last retrospective


### PR DESCRIPTION
- Moderator permissions on the release room can be important to schedule meetings there and distribute information via the room topic
- Drop milestones entirely, projects are the superior management solution.
- Add a hint to create an issue on the artwork repository and ping people who created previous logos