### PR TITLE
Add QEMU emulation hint for installer tests

### DIFF
--- a/src/Final-Release.md
+++ b/src/Final-Release.md
@@ -18,6 +18,7 @@
 - Ensure the following items are sufficiently tested:
   - Graphical NixOS installer images (Can be found on nixos hydra jobset)
   - Minimal NixOS installer images (Can be found on nixos hydra jobset)
+  - If not suitable hardware can be accessed, use [QEMU emulation](https://gist.github.com/mweinelt/b7399e31a05e2e9659acf52b842a417c) for basic testing
 
 - Gather some information about the release for the final announcement
 


### PR DESCRIPTION
Testing of the aarch64-linux ISOs should happen, despite the fact that suitable hardware is not readily available. Recommend QEMU emulation in that scenario. It is slow, but it works.

We can move the script into the documentation, if you think that's a good idea.