### PR TITLE
Branch-Off: Set SUPPORT_END= in /etc/os-release

### DIFF
--- a/src/Branch-Off.md
+++ b/src/Branch-Off.md
@@ -119,6 +119,8 @@ Inputs:
 
    Use the description `Backport PR automatically` and the color value `#0fafaa`
 
+1. Add `SUPPORT_END=YYYY-MM-DD` to `osReleaseContents` in `nixos/modules/misc/version.nix` on the release branch.
+
 1. Update the flake input of nixos-search once the Pull Request in `nixos-org-configurations` is merged and the nixos-21.05 channel is available on [channels.nixos.org](https://channels.nixos.org):
    - Clone [nixos-search](https://github.com/NixOS/nixos-search)
    - Update the flake inputs:


### PR DESCRIPTION
With systemd v252 an unsupported OS version will received the `support-ended` taint flag.

```
        * Systemd will set the taint flag 'support-ended' if it detects that
          the OS image is past its end-of-support date. This date is declared
          in a new /etc/os-release field SUPPORT_END= described below.
```

```
        * os-release gained a new field SUPPORT_END=YYYY-MM-DD to inform the
          user when their system will become unsupported.
```