### PR TITLE
Final Release: Make sure we tag only after pushing

### DIFF
--- a/src/Final-Release.md
+++ b/src/Final-Release.md
@@ -135,10 +135,16 @@ export NEWVER=23.05
 
 1. Cherry-pick the release commit from master
 
-1. Tag the release **on the release branch**:
+1. Push the commit to the release branch
 
    ```bash
-   git tag --annotate --message="Release $NEWVER" $NEWVER
+   git push
+   ````
+
+1. Find the commit id and tag the release **on the release branch**:
+
+   ```bash
+   git tag --annotate --message="Release $NEWVER" $NEWVER <COMMIT_ID>
    git push upstream $NEWVER
    ```
 


### PR DESCRIPTION
Having successfully pushed the release commit ensures the commit ID is stable and can be used for tagging.

Previously tagging the commit locally and then running into a merge conflict would make you do a rebase, which in turn would make your tag point to an old commit id

cc @vcunat