### PR TITLE
feat: remove AMI uploading of the process

### DIFF
--- a/src/Branch-Off.md
+++ b/src/Branch-Off.md
@@ -167,14 +167,4 @@ The following steps should be done after the channels have become available on [
 
 1. Give the [Marketing team](https://matrix.to/#/#marketing:nixos.org) a heads-up about the upcoming release
 
-1. Get in contact with [Amine Chikhaoui](https://github.com/AmineChikhaoui) on the infrastructure room on Matrix, so
-   they can get the AMIs updated in time for the release.
-
-   1. They will need to run [`create-amis.sh`](https://github.com/NixOS/nixpkgs/blob/master/nixos/maintainers/scripts/ec2/create-amis.sh),
-      which requires write permissions to the S3 bucket.
-
-   1. Create PR adding it to NixOS configuration. Examples:
-      - [22.11](https://github.com/NixOS/nixpkgs/pull/204014)
-      - [20.09](https://github.com/NixOS/nixpkgs/pull/101720)
-
 1. Make sure the release editors have started finalizing the release notes. Only 7 days left until release!

--- a/src/Final-Release.md
+++ b/src/Final-Release.md
@@ -207,8 +207,6 @@ export NEWVER=23.05
    nix-shell -p "python3.withPackages (p: [ p.lxml p.requests p.pytest ])" -p cdrkit osinfo-db-tools gettext --run "make check"
    ```
 
-1. Check that the AMI image references have been updated in `nixos/modules/virtualisation/amazon-ec2-amis.nix`.
-
 1. Close the [milestone](https://github.com/NixOS/nixpkgs/milestones)
 
 1. Close the [blockers project](https://github.com/orgs/NixOS/projects)


### PR DESCRIPTION
AMI uploading has been painful for the release management community as the AWS maintenance story in nixpkgs has been degrading, we propose to stop doing this for 24.05 just after the 23.11 process.

Related PR: https://github.com/NixOS/nixpkgs/pull/269240.

cc @AmineChikhaoui @arianvp @figsoda @zimbatm 