### PR TITLE
move updating PULL_REQUEST_TEMPLATE.md and CONTRIBUTING.md from final release to branch-off

### DIFF
--- a/src/Branch-Off.md
+++ b/src/Branch-Off.md
@@ -125,6 +125,15 @@ Now we prepare the master branch for the next release after this one.
 1. Create a new [release notes file](https://github.com/NixOS/nixpkgs/commit/01268fda85b7eee4e462c873d8654f975067731f#diff-e7ee5ff686cdcc513ca089d6e5682587R11)
    for the next release
 
+1. Update the release versions in [`PULL_REQUEST_TEMPLATE.md`](https://github.com/NixOS/nixpkgs/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
+   on master.
+
+   Examples: [22.11](https://github.com/NixOS/nixpkgs/commit/f1b9cc23aa8b1549dd7cb53dbe9fc950efc97646#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35)
+
+1. Update [`CONTRIBUTING.md`](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) on master
+
+   Examples: [22.11](https://github.com/NixOS/nixpkgs/commit/f1b9cc23aa8b1549dd7cb53dbe9fc950efc97646#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055)
+
 1. Commit the changes ([22.05 example](https://github.com/NixOS/nixpkgs/commit/bfdfe12c788d7474b88e7a7790b88b1c0f8e01b5) + [this additional commit](https://github.com/NixOS/nixpkgs/commit/953b5d19bca4d4ddfaef5625cca277c47b39f5e7))
 
 1. Tag the master branch, so that `git describe` shows the new version as the base for commits..

--- a/src/Final-Release.md
+++ b/src/Final-Release.md
@@ -115,15 +115,6 @@ export NEWVER=23.05
 
    1. Update `rl-$NEWVER.section.md` with the final release date.
 
-   1. Update the release versions in [`PULL_REQUEST_TEMPLATE.md`](https://github.com/NixOS/nixpkgs/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
-      on master.
-
-      Examples: [22.11](https://github.com/NixOS/nixpkgs/commit/f1b9cc23aa8b1549dd7cb53dbe9fc950efc97646#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35)
-
-   1. Update [`CONTRIBUTUTING.md`](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) on master
-
-      Examples: [22.11](https://github.com/NixOS/nixpkgs/commit/f1b9cc23aa8b1549dd7cb53dbe9fc950efc97646#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055)
-
    1. Commit and push all changes.
    
       ```bash


### PR DESCRIPTION
IMO it makes more sense to guide people to the new release notes (24.05 in this instance) after it's been created, since changes to the upcoming release (23.11) would need to be backported once branch-off happens.