### PR TITLE
Release-Managers: Make ongoing conflicts a criteria

### DIFF
--- a/src/Release-Managers.md
+++ b/src/Release-Managers.md
@@ -33,4 +33,6 @@ This team has special write permissions to certain repositories in NixOS.
 It is **very** important that the new co-release-manager removes the previous manager
 from the team when they assign a new one.
 
-A release manager must have the commit bit in the nixpkgs repository.
+A release manager must have the commit bit in the nixpkgs repository and must not
+be part of an ongoing conflict, that would impact the execution of their duties
+in this role.


### PR DESCRIPTION
The release manager role is primarily one that is about communication. If a release manager would be part of an ongoing conflict it could prevent them from effectively communicating with various maintainers on nixpkgs.

There is also a chance it coudl taint and potentially overshadow the release process, a risk that should be mitigated early on.