### PR TITLE
Final-Release: use a more descriptive git tag

### DIFF
--- a/src/Final-Release.md
+++ b/src/Final-Release.md
@@ -141,7 +141,7 @@ export NEWVER=23.05
 1. Find the commit id and tag the release **on the release branch**:
 
    ```bash
-   git tag --annotate --message="Release $NEWVER" $NEWVER <COMMIT_ID>
+   git tag --annotate --message="Release $NEWVER" "branch-off-$NEWVER" <COMMIT_ID>
    git push upstream $NEWVER
    ```
 


### PR DESCRIPTION
Use a more descriptive git tag for the release.

The problem with a `24.05`-style tag is, that they *will* land in peoples pinned sources - and those people will wonder why they never get any updates.

This changes hopes to make this less prevalent by adding a more descriptive name for the actual git tag: It tags the branch-off for the new channel release, but it is *not* the actual channel.