### PR TITLE
Update the release schedule to include updated branch names and AoE tz

### DIFF
--- a/src/Release-Process.md
+++ b/src/Release-Process.md
@@ -9,8 +9,8 @@ With [RFC85](https://github.com/NixOS/rfcs/blob/master/rfcs/0085-nixos-release-s
 | Weeks from Release | Branches Affected | Events |
 | --- | --- | --- |
 | -8 Weeks | | Start discussion about "Feature Freeze & Release Blockers" with ecosystems maintainers |
-| -6 Weeks | `staging-next`, `staging` | Restrict breaking changes to Release Critical Packages |
-| -4 Weeks | `staging-next`, `staging` | Restrict all breaking changes with the exception of updates to desktop environment |
+| -6 Weeks | All branches | Restrict breaking changes to Release Critical Packages |
+| -4 Weeks | All branches | Restrict all breaking changes with the exception of updates to desktop environment |
 | -3 Weeks | `master` | Wait for `staging-next` merge into `master`, begin first `staging-next` cycle |
 | -3 Weeks | `master` | Begin Zero Hydra Failures campaign |
 | -2 Weeks | `master` | Wait for first `staging-next` merge into `master`; begin second `staging-next` cycle |
@@ -20,14 +20,15 @@ With [RFC85](https://github.com/NixOS/rfcs/blob/master/rfcs/0085-nixos-release-s
 | -1 Weeks | `master`, `release` | Perform Branch-off, create release channels, create new beta / unstable tags |
 | -1 Weeks | `master` | Mark failing packages as broken |
 | -1 Weeks | `master`, `release` | Create the release branch and tags |
-| -1 Weeks | `release` | Create release channels |
+| -1 Weeks | `release-xx.xx` | Create release channels |
 | -1 Weeks | `master`, `release` | Fixes need to use the "backport" workflow to arrive in the release |
 | -1 Weeks | `master` | Unrestrict all breaking changes; new changes will not be present in the release |
-| -1 Weeks | `release` | Prepare for release, finish remaining issues |
-| 0 Weeks | `release` | **Release!** Marks the end of the Zero Hydra Failures campaign. |
+| -1 Weeks | `release-xx.xx` | Prepare for release, finish remaining issues |
+| 0 Weeks | `release-xx.xx` | **Release!** Marks the end of the Zero Hydra Failures campaign. |
 | +1 Weeks | | Release Retrospective, everyone is invited to give feedback! |
 | +4 Weeks | | End of life cleanup |
 
+As Nixpkgs is a project with contributors spanning across many timezones, it is best to make the dates go into effect in accordance to the [Anywhere on Earth (AoE) timezone](https://www.timeanddate.com/time/zones/aoe).
 
 Clarification of terms:
 


### PR DESCRIPTION
This change was made as the 24.05 release schedule diverges from the current release schedule. Also, to clear up any confusion as to when things go into effect, mentioning that it would be best to use the AoE timezone.