### PR TITLE
update LXC/Incus to match supported versions

### DIFF
--- a/src/Branch-Off.md
+++ b/src/Branch-Off.md
@@ -178,6 +178,10 @@ The following steps should be done after the channels have become available on [
 
 1. Make sure the release editors have started finalizing the release notes. Only 7 days left until release!
 
+1. Add release to LXC/Incus image server
+
+   Ping [Adam C. Stephens](https://github.com/adamcstephens) or open a Pull Request to [lxc/lxc-ci](https://github.com/lxc/lxc-ci/blob/720a50e23f9a122694056d7394226476ae24f973/jenkins/jobs/image-nixos.yaml#L19-L21)
+
 ## For Release Editors
 
 Following a branch-off, Release Editors should keep in mind that the release notes between `master`

--- a/src/EOL-Cleanup.md
+++ b/src/EOL-Cleanup.md
@@ -25,3 +25,7 @@ gets released. At that point a few cleanup tasks need to be done.
    the oldest supported release.
 
    Examples: [22.05](https://github.com/NixOS/nixpkgs/pull/180152)
+
+1. Remove old release from LXC/Incus image server
+
+   Ping [Adam C. Stephens](https://github.com/adamcstephens) or open a Pull Request to [lxc/lxc-ci](https://github.com/lxc/lxc-ci/blob/720a50e23f9a122694056d7394226476ae24f973/jenkins/jobs/image-nixos.yaml#L19-L21)


### PR DESCRIPTION
I've been doing this myself, but since I forgot until today to clean up 24.05 hexa suggested I add this to the release notes. This also helps avoid me being the only person knowledgeable about this. :)